### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@ This module integrates the [Vue 3 Carousel](https://github.com/ismail9k/vue3-car
 ## Installation
 
 ```bash
-npm install vue3-carousel-nuxt
+npx nuxi@latest module add vue3-carousel-nuxt
 ```
 
 or with Yarn:
 
 ```bash
-yarn add vue3-carousel-nuxt
+npx nuxi@latest module add vue3-carousel-nuxt
 ```
 
 ## Usage


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
