### PR TITLE
Fix css loading order;

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -23,7 +23,7 @@ export default defineNuxtModule<CarouselOptions>({
     })
 
     // Add slider css
-    nuxt.options.css.push('vue3-carousel/dist/carousel.css')
+    nuxt.options.css.unshift('vue3-carousel/dist/carousel.css')
     nuxt.options.alias = {
       ...nuxt.options.alias,
       'vue3-carousel/dist/carousel': 'vue3-carousel/dist/carousel.es.js',


### PR DESCRIPTION
This PR puts `"vue3-carousel/dist/carousel.css"` at the beginning of the `css` nuxt options array rather than appending to the end.

The reason is that people may want to override the vars such as
```
:root {
  --vc-nav-color: #fff;
}
```
in their css files. Before this change, the vars in `"vue3-carousel/dist/carousel.css"` would always override the previous css.

Alternatively, just put a warning in the docs. Another easy way to fix this is putting these vars in the vue component where the carousel is being used e.g.:
```
<template>
  <Carousel>
  ...
  </Carousel>
</template>

<style>
:root {
  --vc-nav-color: #fff;
}
</style>

```

